### PR TITLE
빌드 에러 수정

### DIFF
--- a/apps/commerce-client-web/src/app/(default)/(layout)/components/header.tsx
+++ b/apps/commerce-client-web/src/app/(default)/(layout)/components/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import HeaderButton from './header-button';
@@ -10,7 +10,7 @@ import Search from './search';
 
 const Header = () => {
   return (
-    <header className="w-full border-b bg-background md:p-4">
+    <header className="bg-background w-full border-b md:p-4">
       <div className="container mx-auto flex h-14 items-center justify-between md:h-fit">
         {/* 로고 */}
         <div className="shrink-0">
@@ -36,7 +36,9 @@ const Header = () => {
 
         {/* 검색 바 (모바일에서 숨김) */}
         <div className="mx-4 hidden max-w-xs grow md:flex md:max-w-md lg:max-w-lg">
-          <Search />
+          <Suspense fallback="로딩 중..">
+            <Search />
+          </Suspense>
         </div>
 
         {/* 버튼들 (데스크탑용) */}

--- a/apps/commerce-client-web/src/app/(default)/details/[id]/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/details/[id]/page.tsx
@@ -3,9 +3,9 @@
 import React, { useEffect, useState, useRef, Suspense } from 'react';
 import { useParams } from 'next/navigation';
 import products from '@/data/products.json'; // Adjust path as necessary
-import Breadcrumb from '@/app/components/Breadcrumb';
 import { Product } from '@/types/productTypes';
 import { parseAndRoundPrice } from '@/lib/utils';
+import Breadcrumb from '@/app/(default)/search/components/Breadcrumb';
 
 // 카테고리 한글명 변환 객체
 const categoryTranslation: { [key: string]: string } = {
@@ -73,7 +73,7 @@ const ProductDetailsPage = () => {
     : null;
 
   return (
-    <div className="max-w-5xl mx-auto p-4">
+    <div className="mx-auto max-w-5xl p-4">
       <Breadcrumb items={breadcrumbItems} />
 
       <div className="flex">
@@ -81,21 +81,21 @@ const ProductDetailsPage = () => {
           <img
             src={product.coverImage}
             alt={product.title}
-            className="w-full h-auto rounded-lg shadow-lg"
+            className="h-auto w-full rounded-lg shadow-lg"
           />
         </div>
 
         <div className="w-2/3 pl-6">
-          <h1 className="text-2xl font-semibold mb-2">{product.title}</h1>
+          <h1 className="mb-2 text-2xl font-semibold">{product.title}</h1>
           <p className="text-sm text-gray-600">
             {product.author} | {product.publisher} | {product.pubdate}
           </p>
 
-          <div className="mt-4 mb-6">
+          <div className="mb-6 mt-4">
             {product.discount > 0 ? (
               <>
                 <p className="text-lg font-semibold text-gray-900">
-                  정가: <span className="line-through text-red-500">{originalPrice}</span>
+                  정가: <span className="text-red-500 line-through">{originalPrice}</span>
                 </p>
                 <p className="text-lg font-semibold text-red-600">판매가: {discountedPrice}원</p>
               </>
@@ -104,30 +104,30 @@ const ProductDetailsPage = () => {
             )}
           </div>
 
-          <p className="text-gray-700 mb-4">{product.description}</p>
+          <p className="mb-4 text-gray-700">{product.description}</p>
         </div>
 
-        <div className="w-1/4 ml-6">
-          <div className="p-4 bg-gray-50 border rounded-lg shadow-sm">
-            <div className="flex items-center justify-between mb-4">
+        <div className="ml-6 w-1/4">
+          <div className="rounded-lg border bg-gray-50 p-4 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
               <button
-                className="text-lg px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-200"
+                className="rounded-lg border border-gray-300 px-3 py-1 text-lg hover:bg-gray-200"
                 onClick={handleDecrease}
               >
                 -
               </button>
               <span className="text-lg">{quantity}</span>
               <button
-                className="text-lg px-3 py-1 border border-gray-300 rounded-lg hover:bg-gray-200"
+                className="rounded-lg border border-gray-300 px-3 py-1 text-lg hover:bg-gray-200"
                 onClick={handleIncrease}
               >
                 +
               </button>
             </div>
-            <button className="w-full py-2 mb-2 bg-green-500 text-white font-semibold rounded-lg hover:bg-green-600">
+            <button className="mb-2 w-full rounded-lg bg-green-500 py-2 font-semibold text-white hover:bg-green-600">
               카트에 넣기
             </button>
-            <button className="w-full py-2 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600">
+            <button className="w-full rounded-lg bg-blue-500 py-2 font-semibold text-white hover:bg-blue-600">
               바로구매
             </button>
           </div>
@@ -179,9 +179,9 @@ const ProductDetailsPage = () => {
         </div>
 
         <div ref={reviewsRef} className="mt-8">
-          <h2 className="text-xl font-semibold mb-2">리뷰/한줄평</h2>
+          <h2 className="mb-2 text-xl font-semibold">리뷰/한줄평</h2>
           <div>
-            {product.reviews?.length > 0 ? (
+            {product.reviews && product.reviews.length > 0 ? (
               product.reviews.map((review, index) => (
                 <p key={index} className="mb-2">
                   {review}
@@ -194,12 +194,12 @@ const ProductDetailsPage = () => {
         </div>
 
         <div ref={shippingRef} className="mt-8">
-          <h2 className="text-xl font-semibold mb-2">배송/반품/교환</h2>
+          <h2 className="mb-2 text-xl font-semibold">배송/반품/교환</h2>
           <div>배송/반품/교환 정보가 여기에 표시됩니다.</div>
         </div>
 
         <div ref={productInfoRef} className="mt-8">
-          <h2 className="text-xl font-semibold mb-2">품목정보</h2>
+          <h2 className="mb-2 text-xl font-semibold">품목정보</h2>
           <div>품목정보가 여기에 표시됩니다.</div>
         </div>
       </div>

--- a/apps/commerce-client-web/src/app/(default)/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/page.tsx
@@ -1,6 +1,6 @@
 import SliderBanner from '@/app/(default)/(home)/components/slidebanner';
 
-export const mockImages = [
+const mockImages = [
   { src: '/mockbannerimage/book1.png', alt: 'Banner 1' },
   { src: '/mockbannerimage/book2.png', alt: 'Banner 2' },
 ];

--- a/apps/commerce-client-web/src/app/(default)/search/components/(filters)/FilterComponent.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/(filters)/FilterComponent.tsx
@@ -3,15 +3,18 @@ import PriceFilter from '@/app/(default)/search/components/(filters)/PriceFilter
 import PublisherFilter from '@/app/(default)/search/components/(filters)/PublisherFilter';
 import CategoryFilter from '@/app/(default)/search/components/(filters)/CategoryFilter';
 import { Product } from '@/types/productTypes';
+import { Suspense } from 'react';
 
 const FilterComponent = ({ products }: { products: Product[] }) => {
   const publishers = [...new Set(products.map((product) => product.publisher))];
 
   return (
-    <div className="w-full max-w-md p-4 border rounded-lg">
+    <div className="w-full max-w-md rounded-lg border p-4">
       <Accordion type="multiple" className="w-full">
         <PriceFilter />
-        <PublisherFilter publishers={publishers} />
+        <Suspense fallback="로딩 중..">
+          <PublisherFilter publishers={publishers} />
+        </Suspense>
         <CategoryFilter products={products} />
       </Accordion>
     </div>

--- a/apps/commerce-client-web/src/app/(default)/search/components/Breadcrumb.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/Breadcrumb.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import Link from 'next/link';
-import { BreadCrumbProps } from '@/types/breadCrumbTypes'; // 인터페이스를 가져오기
+
+interface BreadCrumbProps {
+  items: {
+    href: string;
+    label: string;
+  }[];
+}
 
 function Breadcrumb({ items }: BreadCrumbProps) {
   return (
-    <nav className="text-sm text-gray-500 mb-4">
+    <nav className="mb-4 text-sm text-gray-500">
       {items.map((item, index) => (
         <span key={index}>
           <Link href={item.href} className="hover:underline">

--- a/apps/commerce-client-web/src/app/(default)/search/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/page.tsx
@@ -1,20 +1,27 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import FilterComponent from '@/app/(default)/search/components/(filters)/FilterComponent';
 import SearchResult from '@/app/(default)/search/components/(searchResult)/SearchResult';
 import productsData from '@/data/products.json';
 
-const SearchPage = () => {
-  const searchParams = useSearchParams();
+interface SearchPageProps {
+  searchParams: {
+    SearchWord?: string;
+    price?: string;
+    publisher?: string;
+    category?: string;
+  };
+}
+
+const SearchPage = ({ searchParams }: SearchPageProps) => {
   const [filteredProducts, setFilteredProducts] = useState(productsData);
 
   useEffect(() => {
-    const searchWord = searchParams.get('SearchWord') || '';
-    const priceRange = searchParams.get('price') || '';
-    const selectedPublisher = searchParams.get('publisher') || '';
-    const selectedCategory = searchParams.get('category') || '';
+    const searchWord = searchParams.SearchWord ?? '';
+    const priceRange = searchParams.price ?? '';
+    const selectedPublisher = searchParams.publisher ?? '';
+    const selectedCategory = searchParams.category ?? '';
 
     let filtered = productsData;
 

--- a/apps/commerce-client-web/src/types/productTypes.ts
+++ b/apps/commerce-client-web/src/types/productTypes.ts
@@ -19,6 +19,7 @@ export type Product = {
       name: string;
     };
   };
+  reviews?: string[];
 };
 
 // SearchResultProps 타입 정의


### PR DESCRIPTION
`commerce-client-web`을 빌드할 때 에러가 발생해서 수정한 내용입니다.

- `header.tsx`, `FilterCompnent.tsx` - `useSearchParams`를 사용하면 `Suspense`로 감싸줘야 합니다. [missing-suspense-with-csr-bailout](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout) 참고
- `search/page.tsx` - 페이지 컴포넌트에서는 `useSearchParams` 대신 `props`로 `searchParams`를 받아올 수 있습니다.
- `(default)/page.tsx` - `mockImages`를 `export` 해서 발생한 문제 -> next의 페이지 컴포넌트에서는 정해진 이름을 제외하고는 `export`를 하면 안 됩니다. e.g. `dynamic`, `generateStaticParams`
- `(details)/[id]/page.tsx` - `reviews` 타입 에러 -> `productTypes`의 `Product` 타입에 `reviews?: string[]`를 임시로 추가해서 해결
- `Breadcrumb.tsx` - 파일 위치 이동 또는 머지하면서 필요한 파일을 찾지 못하는 문제 -> 임시 타입을 만들어서 해결