### PR TITLE
Feature/order: 바로구매, 주문하기 기능 

### DIFF
--- a/apps/commerce-client-web/src/app/(default)/details/[id]/components/detail-button-actions.tsx
+++ b/apps/commerce-client-web/src/app/(default)/details/[id]/components/detail-button-actions.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { Book } from '@/types/book-types';
 import AddToCartButton from '@/app/(default)/cart/components/cart-add-button';
+import PaymentAddButton from '@/app/(default)/order/components/payment-add-button';
 
 interface CartActionsProps {
   book: Book;
@@ -43,7 +43,8 @@ const DetailButtonActions = ({ book }: CartActionsProps) => {
       </div>
       {/* AddToCartButton에 로컬 상태 quantity를 전달 */}
       <AddToCartButton book={book} quantity={quantity} />
-      <Button className="mt-2.5 w-full">바로구매</Button>
+      <PaymentAddButton text={'바로구매'} book={book} />
+      {/* <Button className="mt-2.5 w-full">바로구매</Button> */}
     </div>
   );
 };

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-add-button.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-add-button.tsx
@@ -30,38 +30,43 @@ const PaymentAddButton = ({ text, book }: PaymentForOrderButtonProps) => {
     const currentPath = window.location.pathname;
     const selectedProducts = getSelectedProduct();
 
+    // 장바구니에서 구매하는 경우
     if (currentPath === '/cart' && selectedProducts.length > 0) {
+      router.push('/order');
+    }
+    // 책이 있는 경우 다이얼로그를 띄움
+    else if (book) {
       if (selectedProducts.length > 0) {
-        router.push('/order');
+        setShowDialog(true); // 다이얼로그 띄우기
       } else {
-        alert('장바구니에서 상품을 선택해주세요.');
+        router.push(`/order?productId=${book.id}`); // 바로 구매
       }
-    } else if (book) {
-      if (selectedProducts.length > 0) {
-        setShowDialog(true);
-      } else {
-        router.push(`/order?productId=${book.id}`);
-      }
-    } else {
+    }
+    // 상품이 없는 경우
+    else {
       alert('상품을 선택해주세요.');
     }
   };
 
+  // 장바구니 상품과 함께 구매
   const handleDialogConfirm = () => {
-    setShowDialog(false);
+    setShowDialog(false); // 다이얼로그 닫기
     if (!book) return;
-    addBook(book);
-    router.push('/order');
-  };
-  const handleDialogBuyJustOne = () => {
-    setShowDialog(false);
-    if (!book || !book.id) return;
-    router.push(`/order?productId=${book.id}`);
-  };
-  const handleDialogCancel = () => {
-    setShowDialog(false);
+    addBook(book); // 선택한 책을 장바구니에 추가
+    router.push('/cart'); // 결제 페이지로 이동
   };
 
+  // 선택한 상품만 바로 구매
+  const handleDialogBuyJustOne = () => {
+    setShowDialog(false); // 다이얼로그 닫기
+    if (!book || !book.id) return;
+    router.push(`/order?productId=${book.id}`); // 해당 책만 결제
+  };
+
+  // 취소 동작, 다이얼로그만 닫고 페이지 이동 없음
+  const handleDialogCancel = () => {
+    setShowDialog(false); // 다이얼로그 닫기만 함
+  };
   return (
     <>
       <Button onClick={goPayment} className="w-full">
@@ -72,7 +77,7 @@ const PaymentAddButton = ({ text, book }: PaymentForOrderButtonProps) => {
       {showDialog && (
         <AlertDialogComponent
           title="장바구니에 상품이 있습니다"
-          description="장바구니에 담긴 상품과 함께 구매하시겠습니까?"
+          description="장바구니 확인 후 함께 구매하시겠습니까?"
           onConfirm={handleDialogConfirm}
           onCancel={handleDialogCancel}
           thirdButtonName={'바로구매'}

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-add-button.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-add-button.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import useCartStore from '@/stores/use-cart-store';
+import { useRouter } from 'next/navigation';
+import { Book } from '@/types/book-types';
+
+interface PaymentForOrderButtonProps {
+  text: string;
+  book?: Book;
+}
+const PaymentAddButton = ({ text, book }: PaymentForOrderButtonProps) => {
+  const router = useRouter();
+  const getSelectedProduct = useCartStore((state) => state.getSelectedBook);
+
+  const goPayment = (e: { stopPropagation: () => void }) => {
+    e.stopPropagation();
+
+    // product가 존재하고 discount 속성이 있는지 확인
+    if (book && book.discount < 1) {
+      alert('품절상품입니다');
+      return;
+    }
+
+    const currentPath = window.location.pathname;
+    const selectedProducts = getSelectedProduct();
+
+    if (currentPath === '/cart') {
+      if (selectedProducts.length > 0) {
+        router.push('/order');
+      } else {
+        alert('장바구니에서 상품을 선택해주세요.');
+      }
+    } else if (book) {
+      router.push(`/order?productId=${book.id}`);
+    } else {
+      alert('상품을 선택해주세요.');
+    }
+  };
+
+  return (
+    <Button onClick={goPayment} className="w-full">
+      {text}
+    </Button>
+  );
+};
+
+export default PaymentAddButton;

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-add-button.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-add-button.tsx
@@ -1,22 +1,27 @@
 'use client';
 
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import useCartStore from '@/stores/use-cart-store';
 import { useRouter } from 'next/navigation';
 import { Book } from '@/types/book-types';
+import AlertDialogComponent from '@/components/common/alert-dialog'; // 경고 다이얼로그
 
 interface PaymentForOrderButtonProps {
   text: string;
   book?: Book;
 }
+
 const PaymentAddButton = ({ text, book }: PaymentForOrderButtonProps) => {
   const router = useRouter();
   const getSelectedProduct = useCartStore((state) => state.getSelectedBook);
+  const addBook = useCartStore((state) => state.addBook);
+  const [showDialog, setShowDialog] = useState(false);
 
   const goPayment = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
 
-    // product가 존재하고 discount 속성이 있는지 확인
+    // 품절된 상품인지 확인
     if (book && book.discount < 1) {
       alert('품절상품입니다');
       return;
@@ -25,23 +30,56 @@ const PaymentAddButton = ({ text, book }: PaymentForOrderButtonProps) => {
     const currentPath = window.location.pathname;
     const selectedProducts = getSelectedProduct();
 
-    if (currentPath === '/cart') {
+    if (currentPath === '/cart' && selectedProducts.length > 0) {
       if (selectedProducts.length > 0) {
         router.push('/order');
       } else {
         alert('장바구니에서 상품을 선택해주세요.');
       }
     } else if (book) {
-      router.push(`/order?productId=${book.id}`);
+      if (selectedProducts.length > 0) {
+        setShowDialog(true);
+      } else {
+        router.push(`/order?productId=${book.id}`);
+      }
     } else {
       alert('상품을 선택해주세요.');
     }
   };
 
+  const handleDialogConfirm = () => {
+    setShowDialog(false);
+    if (!book) return;
+    addBook(book);
+    router.push('/order');
+  };
+  const handleDialogBuyJustOne = () => {
+    setShowDialog(false);
+    if (!book || !book.id) return;
+    router.push(`/order?productId=${book.id}`);
+  };
+  const handleDialogCancel = () => {
+    setShowDialog(false);
+  };
+
   return (
-    <Button onClick={goPayment} className="w-full">
-      {text}
-    </Button>
+    <>
+      <Button onClick={goPayment} className="w-full">
+        {text}
+      </Button>
+
+      {/* 함께 구매 여부 확인을 위한 다이얼로그 */}
+      {showDialog && (
+        <AlertDialogComponent
+          title="장바구니에 상품이 있습니다"
+          description="장바구니에 담긴 상품과 함께 구매하시겠습니까?"
+          onConfirm={handleDialogConfirm}
+          onCancel={handleDialogCancel}
+          thirdButtonName={'바로구매'}
+          onThirdAction={handleDialogBuyJustOne}
+        />
+      )}
+    </>
   );
 };
 

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-page-client.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-page-client.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import PaymentProducts from '@/app/(default)/order/components/payment-products';
+import PaymentSummary from '@/app/(default)/order/components/payment-summary';
+import OrderShippingInfo from '@/app/(default)/order/components/payment-shippinginfo';
+import OrderPaymentMethod from '@/app/(default)/order/components/payment-method';
+import PaymentAgreement from '@/app/(default)/order/components/payment-agreement';
+import PaymentUserInfo from '@/app/(default)/order/components/payment-userInfo';
+import useCartStore from '@/stores/use-cart-store';
+import { CartItem } from '@/types/cart-types';
+
+interface PaymentPageClientProps {
+  serverBooks: CartItem[];
+}
+
+const PaymentPageClient = ({ serverBooks }: PaymentPageClientProps) => {
+  const { getSelectedBook, items } = useCartStore();
+  const [books, setBooks] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    if (serverBooks.length > 0) {
+      // 서버에서 전달된 데이터가 있으면 사용
+      setBooks(serverBooks);
+    } else {
+      // 서버에서 데이터가 없으면 클라이언트 상태에서 가져옴
+      setBooks(getSelectedBook());
+    }
+  }, [serverBooks, getSelectedBook, items]);
+
+  return (
+    <div className="container mx-auto p-6">
+      <h1 className="mb-8 text-center text-2xl font-semibold">결제하기</h1>
+
+      {/* 그리드 설정: 기본 1열, md(768px) 이상 2열 */}
+      <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-2">
+        {/* 주문 상품 정보 */}
+        <PaymentProducts books={books} />
+
+        {/* 주문 요약 */}
+        <PaymentSummary books={books} />
+
+        {/* 주문자 정보 */}
+        <PaymentUserInfo />
+
+        {/* 배송 정보 */}
+        <OrderShippingInfo />
+
+        {/* 결제수단 */}
+        <OrderPaymentMethod />
+
+        {/* 동의 및 결제하기 */}
+        <PaymentAgreement />
+      </div>
+    </div>
+  );
+};
+
+export default PaymentPageClient;

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-products.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-products.tsx
@@ -2,23 +2,23 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { CartItem } from '@/types/cart-types';
 
 interface PaymentProductsProps {
-  products: CartItem[];
+  books: CartItem[];
 }
 
-const PaymentProducts = ({ products }: PaymentProductsProps) => {
+const PaymentProducts = ({ books }: PaymentProductsProps) => {
   return (
     <Card className="w-full">
       <CardHeader>
         <CardTitle>주문 상품 정보</CardTitle>
       </CardHeader>
       <CardContent>
-        {products?.map((product) => (
-          <div key={product.id} className="mb-4 flex items-center space-x-4">
-            <img src={product.coverImage} alt={product.title} className="size-16 rounded" />
+        {books?.map((books) => (
+          <div key={books.id} className="mb-4 flex items-center space-x-4">
+            <img src={books.coverImage} alt={books.title} className="size-16 rounded" />
             <div>
-              <p className="font-medium">{product.title}</p>
-              <p className="text-gray-500">{product.selectNum}개</p>
-              <p className="font-bold">{product.price}</p>
+              <p className="font-medium">{books.title}</p>
+              <p className="text-gray-500">{books.selectNum}개</p>
+              <p className="font-bold">{books.price}</p>
             </div>
           </div>
         ))}

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-shippinginfo.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-shippinginfo.tsx
@@ -14,7 +14,7 @@ interface OrderType {
   address: string;
   detailAddress: string;
   memo: string;
-  zonecode: string;
+  zonecode?: string;
 }
 
 interface PaymentShippingInfoProps {

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-shippinginfo.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-shippinginfo.tsx
@@ -8,25 +8,18 @@ import { Textarea } from '@/components/ui/textarea';
 import Modal from '@/components/common/modal';
 import DaumPostcode from 'react-daum-postcode';
 
-interface OrderType {
-  name: string;
-  phnum: string;
-  address: string;
-  detailAddress: string;
-  memo: string;
-  zonecode?: string;
-}
-
-interface PaymentShippingInfoProps {
-  order: OrderType;
-  onOrderChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-}
-
 interface PaymentPostAddressModalProps {
-  zonecode: string;
+  zonecode?: string;
   address: string;
 }
-
+const mockOrder = {
+  name: '패스트파이브',
+  phnum: '01024129368',
+  address: '서울',
+  detailAddress: '강남구',
+  memo: '놓고 가주세여',
+  zonecode: '',
+};
 const PaymentPostAddressModal = ({
   isOpen,
   onClose,
@@ -48,9 +41,13 @@ const PaymentPostAddressModal = ({
   );
 };
 
-const PaymentShippingInfo = ({ order, onOrderChange }: PaymentShippingInfoProps) => {
+const PaymentShippingInfo = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-
+  const [order, setOrder] = useState(mockOrder);
+  const onOrderChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setOrder((prev) => ({ ...prev, [name]: value }));
+  };
   // 우편번호 및 주소 데이터 업데이트 함수
   const handleCompletePostcode = (data: PaymentPostAddressModalProps) => {
     const { zonecode, address } = data;

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-userInfo.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-userInfo.tsx
@@ -1,19 +1,19 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useState } from 'react';
 
-interface UserType {
-  name: string;
-  phnum: string;
-  email: string;
-}
-
-interface PaymentUserInfoProps {
-  user: UserType;
-  onUserChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}
-
-const PaymentUserInfo = ({ user, onUserChange }: PaymentUserInfoProps) => {
+const mockUser = {
+  name: '유재석',
+  phnum: '01024129368',
+  email: 'ddd@naver.com',
+};
+const PaymentUserInfo = () => {
+  const [user, setUser] = useState(mockUser);
+  const onUserChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setUser((prev) => ({ ...prev, [name]: value }));
+  };
   return (
     <Card className="w-full">
       <CardHeader>

--- a/apps/commerce-client-web/src/app/(default)/order/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/page.tsx
@@ -1,105 +1,34 @@
-'use client';
-
-import React, { useState, useEffect } from 'react';
-import PaymentProducts from './components/payment-products';
-import PaymentSummary from './components/payment-summary';
-import OrderShippingInfo from './components/payment-shippinginfo';
-import OrderPaymentMethod from './components/payment-method';
-import PaymentAgreement from './components/payment-agreement';
-import PaymentUserInfo from './components/payment-userInfo';
-import useCartStore from '@/stores/use-cart-store';
+import PaymentPageClient from '@/app/(default)/order/components/payment-page-client';
+import mswApi from '@/lib/msw-api';
 import { CartItem } from '@/types/cart-types';
 import { DetailBook } from '@/types/book-types';
-import mswApi from '@/lib/msw-api';
 
-const mockUser = {
-  name: '유재석',
-  phnum: '01024129368',
-  email: 'ddd@naver.com',
-};
+interface PaymentPageProps {
+  searchParams: { productId?: string };
+}
 
-const mockOrder = {
-  name: '패스트파이브',
-  phnum: '01024129368',
-  address: '서울',
-  detailAddress: '강남구',
-  memo: '놓고 가주세여',
-};
+const PaymentPage = async ({ searchParams }: PaymentPageProps) => {
+  let books: CartItem[] = [];
 
-const PaymentPage = () => {
-  const { getSelectedBook, items } = useCartStore();
-  const [books, setBooks] = useState<CartItem[]>([]);
-  const [user, setUser] = useState(mockUser);
-  const [order, setOrder] = useState(mockOrder);
-
-  useEffect(() => {
-    const fetchBookData = async () => {
-      const searchParams = new URLSearchParams(window.location.search);
-      const productId = searchParams.get('productId');
-
-      if (productId) {
-        const bookId = Number(productId);
-        try {
-          const book = await mswApi(`books/${bookId}`).json<DetailBook>();
-
-          if (book) {
-            const cartItem: CartItem = {
-              ...book,
-              selectNum: 1,
-              selected: true,
-              shippingInfo: '무료배송',
-              imageUrl: book.coverImage || undefined,
-            };
-
-            setBooks([cartItem]);
-          }
-        } catch (error) {
-          console.error('Failed to fetch book:', error);
-        }
-      } else {
-        setBooks(getSelectedBook());
+  if (searchParams.productId) {
+    const bookId = Number(searchParams.productId);
+    try {
+      const book = await mswApi(`books/${bookId}`).json<DetailBook>();
+      if (book) {
+        const cartItem: CartItem = {
+          ...book,
+          selectNum: 1,
+          selected: true,
+          shippingInfo: '무료배송',
+          imageUrl: book.coverImage || undefined,
+        };
+        books = [cartItem];
       }
-    };
-
-    fetchBookData();
-  }, [getSelectedBook, items]);
-
-  const handleUserChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setUser((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleOrderChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setOrder((prev) => ({ ...prev, [name]: value }));
-  };
-
-  return (
-    <div className="container mx-auto p-6">
-      <h1 className="mb-8 text-center text-2xl font-semibold">결제하기</h1>
-
-      {/* 그리드 설정: 기본 1열, md(768px) 이상 2열 */}
-      <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-2">
-        {/* 주문 상품 정보 */}
-        <PaymentProducts books={books} />
-
-        {/* 주문 요약 */}
-        <PaymentSummary books={books} />
-
-        {/* 주문자 정보 */}
-        <PaymentUserInfo user={user} onUserChange={handleUserChange} />
-
-        {/* 배송 정보 */}
-        <OrderShippingInfo order={order} onOrderChange={handleOrderChange} />
-
-        {/* 결제수단 */}
-        <OrderPaymentMethod />
-
-        {/* 동의 및 결제하기 */}
-        <PaymentAgreement />
-      </div>
-    </div>
-  );
+    } catch (error) {
+      console.error('Failed to fetch book:', error);
+    }
+  }
+  return <PaymentPageClient serverBooks={books} />;
 };
 
 export default PaymentPage;

--- a/apps/commerce-client-web/src/app/(default)/order/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import PaymentProducts from './components/payment-products';
 import PaymentSummary from './components/payment-summary';
 import OrderShippingInfo from './components/payment-shippinginfo';
@@ -8,7 +8,7 @@ import OrderPaymentMethod from './components/payment-method';
 import PaymentAgreement from './components/payment-agreement';
 import PaymentUserInfo from './components/payment-userInfo';
 import useCartStore from '@/stores/use-cart-store';
-import { CartItem } from '@/types/cart-types'; // CartItem 타입 임포트
+import { CartItem } from '@/types/cart-types';
 
 const mockUser = {
   name: '유재석',
@@ -22,18 +22,26 @@ const mockOrder = {
   address: '서울',
   detailAddress: '강남구',
   memo: '놓고 가주세여',
-  zonecode: '12345',
 };
 
 const PaymentPage = () => {
-  const { getSelectedBook } = useCartStore();
+  const { getSelectedBook, items } = useCartStore();
   const [books, setBooks] = useState<CartItem[]>([]);
   const [user, setUser] = useState(mockUser);
   const [order, setOrder] = useState(mockOrder);
 
   useEffect(() => {
-    setBooks(getSelectedBook());
-  }, [getSelectedBook]);
+    const searchParams = new URLSearchParams(window.location.search);
+    const productId = searchParams.get('productId');
+
+    if (productId) {
+      const id = Number(productId);
+      const product = items.find((item) => item.id === id);
+      if (product) setBooks([product]);
+    } else {
+      setBooks(getSelectedBook());
+    }
+  }, [getSelectedBook, items]);
 
   const handleUserChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -52,7 +60,7 @@ const PaymentPage = () => {
       {/* 그리드 설정: 기본 1열, md(768px) 이상 2열 */}
       <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-2">
         {/* 주문 상품 정보 */}
-        <PaymentProducts products={books} />
+        <PaymentProducts books={books} />
 
         {/* 주문 요약 */}
         <PaymentSummary books={books} />

--- a/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/book-card.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/book-card.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation'; // useRouter 훅 가져오기
-import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
 import { Book } from '@/types/book-types';
 import { parseAndRoundPrice } from '@/lib/utils';
 import AddToCartButton from '@/app/(default)/cart/components/cart-add-button'; // Import the useCartStore hook
+import PaymentAddButton from '@/app/(default)/order/components/payment-add-button';
 
 export type BookCardProps = {
   id: number;
@@ -81,9 +81,7 @@ const BookCard = ({ id, book }: BookCardProps) => {
       {/* Right Side: Buttons */}
       <div className="mt-4 flex flex-row items-end justify-around space-y-2 md:ml-auto md:mt-0 md:flex-col md:justify-start">
         <AddToCartButton book={book} quantity={1} />
-        <Button variant="default" className="w-24">
-          바로구매
-        </Button>
+        <PaymentAddButton text={'바로구매'} book={book} />
       </div>
     </div>
   );

--- a/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/book-card.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/book-card.tsx
@@ -27,57 +27,56 @@ const BookCard = ({ id, book }: BookCardProps) => {
   };
 
   return (
-    <div
-      className="hover:border-primary flex w-full shrink cursor-pointer flex-col rounded-md border p-4 shadow-sm hover:shadow-md sm:w-auto md:flex-row"
-      onClick={handleNavigate}
-    >
-      <div className="flex">
-        {/* Left Side: Image */}
-        <div className="relative h-44 w-32 shrink-0">
-          <Image
-            src={book.coverImage}
-            alt={book.title}
-            fill
-            style={{ objectFit: 'cover' }}
-            className="rounded-lg"
-          />
-        </div>
+    <div className="hover:border-primary flex w-full shrink cursor-pointer flex-col rounded-md border p-4 shadow-sm hover:shadow-md sm:w-auto md:flex-row">
+      <>
+        <div className="flex" onClick={handleNavigate}>
+          {/* Left Side: Image */}
+          <div className="relative h-44 w-32 shrink-0">
+            <Image
+              src={book.coverImage}
+              alt={book.title}
+              fill
+              style={{ objectFit: 'cover' }}
+              className="rounded-lg"
+            />
+          </div>
 
-        {/* Center: Title, Price, Tags */}
-        <div className="mx-4 flex grow flex-col justify-between">
-          <div className="flex flex-col gap-y-1.5 py-2">
-            <h2 className="max-w-96 truncate text-sm font-semibold">{book.title}</h2>
-            <p className="text-xs font-light text-slate-600">
-              {book.author} | {book.publisher} | {book.pubdate}
-            </p>
-            <p className="mt-2 text-sm">
-              {book.discount > 0 ? (
-                <>
-                  <span className="mr-1 font-extrabold">{book.discount.toLocaleString()}원</span>
-                  <span className="text-xs text-slate-400 line-through">
-                    {roundedPrice.toLocaleString()}원
-                  </span>
-                </>
-              ) : (
-                <span className="font-bold">품절</span>
-              )}
-            </p>
-            <p className="hidden text-xs font-light text-slate-500 md:block">
-              {truncateDescription(book.description, maxLength)}
-            </p>
-          </div>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {book.tags.map((tag, index) => (
-              <span
-                key={index}
-                className="gap-2 rounded bg-slate-100 px-2 py-1 text-xs font-light text-slate-400"
-              >
-                #{tag}
-              </span>
-            ))}
+          {/* Center: Title, Price, Tags */}
+          <div className="mx-4 flex grow flex-col justify-between">
+            <div className="flex flex-col gap-y-1.5 py-2">
+              <h2 className="max-w-96 truncate text-sm font-semibold">{book.title}</h2>
+              <p className="text-xs font-light text-slate-600">
+                {book.author} | {book.publisher} | {book.pubdate}
+              </p>
+              <p className="mt-2 text-sm">
+                {book.discount > 0 ? (
+                  <>
+                    <span className="mr-1 font-extrabold">{book.discount.toLocaleString()}원</span>
+                    <span className="text-xs text-slate-400 line-through">
+                      {roundedPrice.toLocaleString()}원
+                    </span>
+                  </>
+                ) : (
+                  <span className="font-bold">품절</span>
+                )}
+              </p>
+              <p className="hidden text-xs font-light text-slate-500 md:block">
+                {truncateDescription(book.description, maxLength)}
+              </p>
+            </div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {book.tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="gap-2 rounded bg-slate-100 px-2 py-1 text-xs font-light text-slate-400"
+                >
+                  #{tag}
+                </span>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      </>
       {/* Right Side: Buttons */}
       <div className="mt-4 flex flex-row items-end justify-around space-y-2 md:ml-auto md:mt-0 md:flex-col md:justify-start">
         <AddToCartButton book={book} quantity={1} />

--- a/apps/commerce-client-web/src/components/common/alert-dialog.tsx
+++ b/apps/commerce-client-web/src/components/common/alert-dialog.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from '@/components/ui/alert-dialog';
+
+interface AlertDialogProps {
+  title: string;
+  description: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  thirdButtonName?: string;
+  onThirdAction?: () => void;
+}
+
+const AlertDialogComponent = ({
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  thirdButtonName,
+  onThirdAction,
+}: AlertDialogProps) => {
+  return (
+    <AlertDialog open onOpenChange={(open) => !open && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>취소</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>확인</AlertDialogAction>
+          <AlertDialogAction onClick={onThirdAction}>{thirdButtonName}</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default AlertDialogComponent;

--- a/apps/commerce-client-web/src/components/common/alert-dialog.tsx
+++ b/apps/commerce-client-web/src/components/common/alert-dialog.tsx
@@ -36,7 +36,9 @@ const AlertDialogComponent = ({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel onClick={onCancel}>취소</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>확인</AlertDialogAction>
+          <AlertDialogAction onClick={onConfirm} className="self-end bg-slate-500">
+            확인
+          </AlertDialogAction>
           <AlertDialogAction onClick={onThirdAction}>{thirdButtonName}</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/commerce-client-web/src/stores/use-cart-store.ts
+++ b/apps/commerce-client-web/src/stores/use-cart-store.ts
@@ -5,7 +5,7 @@ import { persist } from 'zustand/middleware';
 
 export interface CartState {
   items: CartItem[];
-  addBook: (book: Book, quantity: number) => void;
+  addBook: (book: Book, quantity?: number) => void;
   removeBook: (id: number) => void;
   removeAllBook: () => void;
   updateBookQuantity: (id: number, selectNum: number) => void;
@@ -18,7 +18,7 @@ const useCartStore = create<CartState>()(
   persist(
     (set, get) => ({
       items: [],
-      addBook: (book: Book, quantity?: number) =>
+      addBook: (book: Book, quantity: number = 1) =>
         set((state) => {
           // Check if the book already exists in the cart
           if (!book || !book.id) {
@@ -29,7 +29,7 @@ const useCartStore = create<CartState>()(
             // Increment the quantity if the book exists
             return {
               items: state.items.map((item) =>
-                item.id === book.id ? { ...item, selectNum: item.selectNum + quantity ?? 1 } : item,
+                item.id === book.id ? { ...item, selectNum: item.selectNum + quantity } : item,
               ),
             };
           } else {
@@ -39,7 +39,7 @@ const useCartStore = create<CartState>()(
                 ...state.items,
                 {
                   ...book,
-                  selectNum: quantity ?? 1,
+                  selectNum: quantity,
                   selected: true,
                   shippingInfo: '무료',
                 } as CartItem, // Ensure the new item is typed as CartItem

--- a/apps/commerce-client-web/src/types/cart-types.ts
+++ b/apps/commerce-client-web/src/types/cart-types.ts
@@ -4,5 +4,5 @@ export interface CartItem extends Book {
   selectNum: number; // 선택한 수량
   selected: boolean; // 선택 여부
   shippingInfo: string; // 배송 정보 추가
-  imageUrl: string | undefined;
+  imageUrl?: string | undefined;
 }


### PR DESCRIPTION
## 🔘Part

- [x] FE

<br/>

## 🔎 작업 내용

- 바로구매, 주문하기 기능 

  <br/>
![image](https://github.com/user-attachments/assets/79864328-e867-4baf-b3ca-68f139556ca5)

![image](https://github.com/user-attachments/assets/4bca7e33-e7e5-4df9-902b-ef6254ec664d)
##### 적용 화면 : search

 - 장바구니에 들어있는 상품이 있으면 다이얼로그가 뜹니다.
 - 취소 : 다이얼로그 닫기
 - 확인 : 장바구니에 해당상품 +=1 하고 cart 페이지로 이동 
![image](https://github.com/user-attachments/assets/ef379124-305b-46ee-a3b3-1a244883d04a)

 - 바로구매 : 해당 상품 id하나만 들고 구매 페이지로이동
![image](https://github.com/user-attachments/assets/f38fedf1-97ce-4d04-a32f-04416bc95464)


<br/>

## 🔧 앞으로의 과제

장바구니 api 호출 가능하게 되면 전부 서버 컴포넌트로 바꿔야합니다. 현재 
useCartStore도 쓰고 msw 도 쓰려하다보니 클라이언트에서 처리하는 부분이 너무 많습니다. 
  <br/>
