### PR TITLE
Feature/cart order responsive design

### DIFF
--- a/apps/commerce-client-web/src/app/(auth)/login/components/login-form.tsx
+++ b/apps/commerce-client-web/src/app/(auth)/login/components/login-form.tsx
@@ -23,10 +23,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import useAuthStore, { LoginFormData } from '@/stores/use-auth-store';
+
 import { useRouter } from 'next/navigation';
 import { getUserInfo, login } from '@/app/actions/auth-action';
 import { useUserStore } from '@/stores/use-user-store';
+import { LoginFormData, useAuthStore } from '@/stores/use-auth-store';
 
 const LoginForm = () => {
   const router = useRouter();

--- a/apps/commerce-client-web/src/app/(auth)/signup/components/sign-up-form.tsx
+++ b/apps/commerce-client-web/src/app/(auth)/signup/components/sign-up-form.tsx
@@ -2,7 +2,7 @@ import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { SignupSchema } from '@/schemas/auth-schema';
 import PostAddressModal, { PostAddress } from '@/components/common/post-address-modal';
-import useAuthStore, { SignupFormData } from '@/stores/use-auth-store';
+import { useAuthStore, SignupFormData } from '@/stores/use-auth-store';
 
 import { Button } from '@/components/ui/button';
 import { useEffect, useState } from 'react';

--- a/apps/commerce-client-web/src/app/(auth)/signup/page.tsx
+++ b/apps/commerce-client-web/src/app/(auth)/signup/page.tsx
@@ -16,7 +16,7 @@ import {
   AlertDialogAction,
 } from '@/components/ui/alert-dialog';
 import Link from 'next/link';
-import useAuthStore, { LoginFormData } from '@/stores/use-auth-store';
+import { useAuthStore, LoginFormData } from '@/stores/use-auth-store';
 import { login, signUp } from '@/app/actions/auth-action';
 
 const steps = ['약관동의', '정보입력', '가입완료'];

--- a/apps/commerce-client-web/src/app/(default)/cart/components/cart-action-buttons.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/components/cart-action-buttons.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+type CartActionButtonsProps = {
+  allSelected: boolean;
+  onSelectAll: (checked: boolean) => void;
+  onClearCart: () => void;
+};
+
+const CartActionButtons = ({ allSelected, onSelectAll, onClearCart }: CartActionButtonsProps) => (
+  <div className="flex w-full items-center justify-between rounded-lg bg-slate-50 p-4">
+    <div className="flex items-center space-x-2">
+      <Checkbox
+        checked={allSelected}
+        onCheckedChange={onSelectAll}
+        className="cursor-pointer"
+        id="select-all"
+      />
+      <Label htmlFor="select-all" className="text-sm font-medium text-gray-700">
+        전체 선택
+      </Label>
+    </div>
+
+    <Button variant="outline" onClick={onClearCart}>
+      전체삭제
+    </Button>
+  </div>
+);
+
+export default CartActionButtons;

--- a/apps/commerce-client-web/src/app/(default)/cart/components/cart-empty-state.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/components/cart-empty-state.tsx
@@ -1,0 +1,24 @@
+import { ShoppingCart } from 'lucide-react'; // Use Lucide icons or any other icon library you prefer
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+
+const CartEmptyState = () => {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border bg-slate-100 px-4 py-16">
+      <ShoppingCart className="size-12 text-gray-400 md:size-16" />
+      <h2 className="mt-4 text-sm font-semibold text-gray-600 sm:text-base">
+        장바구니에 담긴 상품이 없습니다.
+      </h2>
+      <p className="mt-2 text-xs text-gray-500 sm:text-sm">
+        원하시는 상품을 장바구니에 추가해보세요!
+      </p>
+      <Link href="/search">
+        <Button variant="default" className="mt-6">
+          상품 보러가기
+        </Button>
+      </Link>
+    </div>
+  );
+};
+
+export default CartEmptyState;

--- a/apps/commerce-client-web/src/app/(default)/cart/components/cart-item-list.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/components/cart-item-list.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { useEffect } from 'react';
-import { Table, TableHeader, TableBody, TableRow, TableHead } from '@/components/ui/table';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import CartItem from './cart-item';
+
 import useCartStore from '@/stores/use-cart-store';
 import { CheckedState } from '@radix-ui/react-checkbox';
 import { useWithLoading } from '@/components/common/with-loading-spinner';
+import CartActionButtons from './cart-action-buttons';
+import CartItemsTable from './cart-item-table';
+import CartMobileItem from './cart-mobile-item';
+import CartEmptyState from './cart-empty-state';
 
 const CartItemList = () => {
   const {
@@ -26,7 +27,6 @@ const CartItemList = () => {
   }, [fetchItems, updateQuantity]);
 
   const allSelected = items.length > 0 && checkedItems.length === items.length;
-
   const toBoolean = (checked: CheckedState): boolean => checked === true;
 
   const handleClearCart = () => {
@@ -34,50 +34,50 @@ const CartItemList = () => {
       await Promise.all(items.map((item) => removeCartItems(item.shoppingCartId)));
     });
   };
+
   const handleChangeQuantity = async (shoppingCartId: number, quantity: number) => {
-    // 수량 업데이트 로직 후 fetchItems 호출
     await updateQuantity(shoppingCartId, quantity);
-    withLoading(fetchItems); // 수량 변경 후 아이템들을 다시 가져옴
+    withLoading(fetchItems);
   };
+
   return (
-    <div className="flex flex-col gap-y-5 overflow-x-auto">
-      <Button variant="secondary" className="self-end" onClick={handleClearCart}>
-        전체삭제
-      </Button>
-      <Table className="min-w-full divide-y divide-gray-200">
-        <TableHeader>
-          <TableRow>
-            <TableHead className="w-10">
-              <Checkbox
-                checked={allSelected}
-                onCheckedChange={(checked) =>
-                  withLoading(async () => selectAllItems(toBoolean(checked)))
-                }
-                className="cursor-pointer"
+    <div className="flex w-full flex-col gap-y-5">
+      {items.length === 0 ? (
+        <CartEmptyState />
+      ) : (
+        <>
+          <CartActionButtons
+            allSelected={allSelected}
+            onSelectAll={(checked) => withLoading(async () => selectAllItems(toBoolean(checked)))}
+            onClearCart={handleClearCart}
+          />
+
+          {/* Desktop Design */}
+          <CartItemsTable
+            items={items}
+            checkedItems={checkedItems}
+            onToggleItem={toggleItemSelection}
+            onRemoveItem={removeCartItems}
+            onChangeQuantity={handleChangeQuantity}
+            withLoading={withLoading}
+          />
+
+          {/* Mobile Design */}
+          <div className="flex flex-col space-y-4 md:hidden">
+            {items.map((item) => (
+              <CartMobileItem
+                key={item.shoppingCartId}
+                item={item}
+                checkedItems={checkedItems}
+                onToggleItem={(productId, checked) => toggleItemSelection(productId, checked)}
+                onRemoveItem={removeCartItems}
+                onChangeQuantity={handleChangeQuantity}
+                withLoading={withLoading}
               />
-            </TableHead>
-            <TableHead className="whitespace-nowrap text-center">상품 정보</TableHead>
-            <TableHead className="whitespace-nowrap text-center">수량</TableHead>
-            <TableHead className="whitespace-nowrap text-center">주문 금액</TableHead>
-            <TableHead className="whitespace-nowrap text-center">배송 정보</TableHead>
-            <TableHead className="whitespace-nowrap text-center">삭제</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {items.map((item) => (
-            <CartItem
-              key={item.shoppingCartId}
-              item={item}
-              checked={checkedItems.includes(item.productId)}
-              onCheckedChange={(checked) =>
-                withLoading(async () => toggleItemSelection(item.productId, toBoolean(checked)))
-              }
-              onRemoveItem={() => withLoading(() => removeCartItems(item.shoppingCartId))}
-              onChangeQuantity={handleChangeQuantity}
-            />
-          ))}
-        </TableBody>
-      </Table>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/apps/commerce-client-web/src/app/(default)/cart/components/cart-item-table.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/components/cart-item-table.tsx
@@ -1,0 +1,63 @@
+import { Table, TableHeader, TableBody, TableRow, TableHead } from '@/components/ui/table';
+import CartItem from './cart-item';
+import { CartItem as CartItemType } from '@/types/cart-types';
+import { Checkbox } from '@/components/ui/checkbox';
+
+type CartItemsTableProps = {
+  items: CartItemType[];
+  checkedItems: number[];
+  onToggleItem: (productId: number, checked: boolean) => void;
+  onRemoveItem: (shoppingCartId: number) => void;
+  onChangeQuantity: (shoppingCartId: number, quantity: number) => void;
+  withLoading: (fn: () => Promise<void>) => void;
+};
+
+const CartItemsTable = ({
+  items,
+  checkedItems,
+  onToggleItem,
+  onRemoveItem,
+  onChangeQuantity,
+  withLoading,
+}: CartItemsTableProps) => {
+  // Convert CheckedState to boolean explicitly to prevent type issues
+  const toBoolean = (checked: string | boolean): boolean => checked === true || checked === 'true';
+
+  return (
+    <Table className="hidden min-w-full divide-y divide-slate-200 md:table">
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <Checkbox
+              checked={items.length > 0 && checkedItems.length === items.length}
+              onCheckedChange={async (checked) =>
+                withLoading(async () => onToggleItem(items[0].productId, toBoolean(checked)))
+              }
+              className="cursor-pointer"
+            />
+          </TableHead>
+          <TableHead className="whitespace-nowrap text-center">상품 정보</TableHead>
+          <TableHead className="whitespace-nowrap text-center">수량</TableHead>
+          <TableHead className="whitespace-nowrap text-center">주문 금액</TableHead>
+          <TableHead className="hidden whitespace-nowrap text-center md:table-cell">삭제</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {items.map((item) => (
+          <CartItem
+            key={item.shoppingCartId}
+            item={item}
+            checked={checkedItems.includes(item.productId)}
+            onCheckedChange={async (checked) =>
+              withLoading(async () => onToggleItem(item.productId, toBoolean(checked)))
+            }
+            onRemoveItem={() => onRemoveItem(item.shoppingCartId)}
+            onChangeQuantity={onChangeQuantity}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default CartItemsTable;

--- a/apps/commerce-client-web/src/app/(default)/cart/components/cart-mobile-item.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/components/cart-mobile-item.tsx
@@ -1,0 +1,92 @@
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import Image from 'next/image';
+import { CartItem as CartItemType } from '@/types/cart-types';
+
+type CartMobileItemProps = {
+  item: CartItemType;
+  checkedItems: number[];
+  onToggleItem: (productId: number, checked: boolean) => void;
+  onRemoveItem: (shoppingCartId: number) => Promise<void>;
+  onChangeQuantity: (shoppingCartId: number, quantity: number) => Promise<void>;
+  withLoading: (fn: () => Promise<void>) => void;
+};
+
+const CartMobileItem = ({
+  item,
+  checkedItems,
+  onToggleItem,
+  onRemoveItem,
+  onChangeQuantity,
+  withLoading,
+}: CartMobileItemProps) => (
+  <div key={item.shoppingCartId} className="rounded-lg border bg-white p-4 shadow-sm">
+    <div className="mb-2 flex items-center justify-between">
+      <Checkbox
+        checked={checkedItems.includes(item.productId)}
+        onCheckedChange={(checked) =>
+          withLoading(async () => onToggleItem(item.productId, checked === true))
+        }
+        className="cursor-pointer"
+      />
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => withLoading(() => onRemoveItem(item.shoppingCartId))}
+        className="text-red-500 hover:bg-red-50"
+      >
+        삭제
+      </Button>
+    </div>
+    <div className="flex items-start space-x-4">
+      <Image
+        src={item.coverImage}
+        alt={item.title}
+        width={80}
+        height={80}
+        className="rounded-lg border"
+      />
+      <div className="flex w-full flex-col justify-between">
+        <div className="flex flex-col items-start gap-y-4">
+          <div className="max-w-[150px] truncate text-sm font-semibold">{item.title}</div>
+          <div className="flex items-center justify-center text-sm text-slate-500">
+            <div className="flex gap-x-2">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() =>
+                  onChangeQuantity(item.shoppingCartId, Math.max(item.quantity - 1, 1))
+                }
+                className="p-1"
+              >
+                -
+              </Button>
+              <Input
+                type="number"
+                value={item.quantity}
+                min={1}
+                readOnly
+                className="w-10 rounded border text-center text-xs"
+              />
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => onChangeQuantity(item.shoppingCartId, item.quantity + 1)}
+                className="p-1"
+              >
+                +
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 flex items-center justify-between text-sm">
+          <span className="text-slate-500">상품금액 :</span>
+          <span className="font-bold">{item.discountedPrice.toLocaleString()}원</span>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default CartMobileItem;

--- a/apps/commerce-client-web/src/app/(default)/cart/components/cart-summary.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/components/cart-summary.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Equal, Minus, Plus } from 'lucide-react';
 import useCartStore from '@/stores/use-cart-store';
 import { Button } from '@/components/ui/button';
 import AlertDialog from '@/components/common/alert-dialog';
@@ -51,42 +50,16 @@ const CartSummary = () => {
 
   return (
     <>
-      <div className="mt-8 w-full">
-        <h2 className="mb-4 text-lg font-semibold">결제정보</h2>
+      {/* Desktop Design */}
+      <div className="mt-8 hidden w-full md:block">
+        <h2 className="mb-4 text-lg font-semibold md:text-left">결제정보</h2>
         <div className="rounded-md border border-gray-200 p-4">
           <div className="grid grid-cols-4 gap-4 bg-slate-100 p-4 text-center text-sm font-semibold text-gray-700">
-            <div className="relative">
-              <span>총 상품금액</span>
-              <div className="absolute -right-2 top-1/2 -translate-y-1/2">
-                <div className="flex size-5 items-center justify-center rounded-full bg-slate-400">
-                  <Plus size={16} className="text-white" />
-                </div>
-              </div>
-            </div>
-
-            <div className="relative">
-              <span>총 추가금액</span>
-              <div className="absolute -right-2 top-1/2 -translate-y-1/2">
-                <div className="flex size-5 items-center justify-center rounded-full bg-slate-400">
-                  <Minus size={16} className="text-white" />
-                </div>
-              </div>
-            </div>
-
-            <div className="relative text-blue-500">
-              <span>총 할인금액</span>
-              <div className="absolute -right-2 top-1/2 -translate-y-1/2">
-                <div className="flex size-5 items-center justify-center rounded-full bg-slate-400">
-                  <Equal size={16} className="text-white" />
-                </div>
-              </div>
-            </div>
-
-            <div className="relative text-red-700">
-              <span>최종 결제금액</span>
-            </div>
+            <div>총 상품금액</div>
+            <div>총 추가금액</div>
+            <div className="text-blue-500">총 할인금액</div>
+            <div className="text-red-700">최종 결제금액</div>
           </div>
-
           <div className="grid grid-cols-4 gap-4 p-4 text-center text-lg font-bold">
             <div>{totalItemPrice}원</div>
             <div>0원</div>
@@ -101,12 +74,42 @@ const CartSummary = () => {
         </div>
       </div>
 
-      {/* AlertDialogComponent */}
+      {/* Mobile Design */}
+      <div className="mt-8 block w-full md:hidden">
+        <h2 className="mb-4 text-lg font-semibold">결제정보</h2>
+        <div className="rounded-md border border-gray-200 bg-slate-50 p-4">
+          <div className="flex flex-col space-y-4">
+            <div className="flex justify-between text-sm font-medium">
+              <span>총 상품금액</span>
+              <span>{totalItemPrice}원</span>
+            </div>
+            <div className="flex justify-between text-sm font-medium text-blue-500">
+              <span>총 할인금액</span>
+              <span>{totalDiscount}원</span>
+            </div>
+            <div className="flex justify-between text-sm font-medium">
+              <span>총 추가금액</span>
+              <span>0원</span>
+            </div>
+            <div className="flex justify-between border-t pt-4 text-lg font-bold text-red-600">
+              <span>최종 결제금액</span>
+              <span>{finalPrice}원</span>
+            </div>
+          </div>
+        </div>
+        <div className="mt-6">
+          <Button onClick={handleOrderClick} className="h-12 w-full text-base font-semibold">
+            주문하기
+          </Button>
+        </div>
+      </div>
+
+      {/* AlertDialog Component */}
       {showAlertDialog && (
         <AlertDialog
           title="경고"
           description="최종 결제 금액이 0원입니다. 구매하실 상품을 선택해주세요."
-          onConfirm={() => setShowAlertDialog(false)} // 확인 버튼 클릭 시 다이얼로그 닫기
+          onConfirm={() => setShowAlertDialog(false)}
         />
       )}
     </>

--- a/apps/commerce-client-web/src/app/(default)/cart/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/cart/page.tsx
@@ -3,7 +3,7 @@ import CartSummary from './components/cart-summary';
 
 const CartPage = () => {
   return (
-    <div className="container mx-auto p-6">
+    <div className="p-4 sm:p-0">
       <CartItemList />
       <div className="mt-4 flex justify-end">
         <CartSummary />

--- a/apps/commerce-client-web/src/app/(default)/details/[id]/components/review/review-section.tsx
+++ b/apps/commerce-client-web/src/app/(default)/details/[id]/components/review/review-section.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 import PreviousReviews from './previous-reviews';
 import NewReviewForm from './new-review-form';
 import { Review } from '@/types/review-types';
-import useAuthStore from '@/stores/use-auth-store'; // Import your auth store
+import { useAuthStore } from '@/stores/use-auth-store'; // Import your auth store
 import { fetchProductReviews } from '@/services/review-api';
 
 interface ReviewSectionProps {

--- a/apps/commerce-client-web/src/app/(default)/me/components/side-bar.tsx
+++ b/apps/commerce-client-web/src/app/(default)/me/components/side-bar.tsx
@@ -14,10 +14,7 @@ const menuItems = [
   },
 ];
 
-const sideBarButtons = [
-  { title: '나의 1:1 문의 내역', route: '/inquiries' },
-  { title: '나의 리뷰', route: '/me/reviews' },
-];
+const sideBarButtons = [{ title: '나의 리뷰', route: '/me/reviews' }];
 
 const SideBar = () => {
   return (

--- a/apps/commerce-client-web/src/app/(default)/me/user-info/components/user-info-form.tsx
+++ b/apps/commerce-client-web/src/app/(default)/me/user-info/components/user-info-form.tsx
@@ -12,11 +12,12 @@ import { InputField } from '@/components/common/input-field'; // Use the InputFi
 import { InfoIcon } from 'lucide-react';
 import DeleteAccountDialog from './delete-account-dialog';
 import { useRouter } from 'next/navigation';
-import useAuthStore from '@/stores/use-auth-store';
+import { useAuthStore } from '@/stores/use-auth-store';
 
 const UserInfoForm = () => {
   const router = useRouter();
-  const { userSession, userInfoData, setUserInfoData, authToken, clearAuthToken } = useUserStore();
+  const { userSession, userInfoData, setUserInfoData, authToken, clearAuthToken, resetUserState } =
+    useUserStore();
   const { resetAuthState } = useAuthStore();
   const [isPostAddressModalOpen, setIsPostAddressModalOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -58,6 +59,7 @@ const UserInfoForm = () => {
       await deleteUserAccount();
 
       resetAuthState();
+      resetUserState();
 
       router.push('/');
     } catch (error) {

--- a/apps/commerce-client-web/src/app/(default)/order/components/payment-products.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/components/payment-products.tsx
@@ -14,22 +14,34 @@ const PaymentProducts = ({ books }: PaymentProductsProps) => {
       </CardHeader>
       <CardContent>
         {books?.map((product) => (
-          <div key={`${product.id}`} className="mb-4 flex items-center space-x-4">
-            {/* 상품 이미지 */}
+          <div
+            key={`${product.id}`}
+            className="mb-4 flex items-center space-x-4 md:flex-row md:items-center md:space-x-4"
+          >
+            {/* Desktop Image */}
             <Image
               src={product.coverImage}
               alt={product.title}
               width={80}
               height={50}
-              className="rounded"
-              style={{ width: 'auto', height: 'auto' }} // 이미지 비율 유지
+              className="hidden rounded md:block"
+              style={{ width: 'auto', height: 'auto' }} // Maintain image aspect ratio
             />
 
-            {/* 상품 정보 */}
-            <div className="flex grow items-center justify-between gap-x-4">
-              <p className="flex-1 text-sm font-extralight">{product.title}</p>
-              <p className="text-sm">{product.quantity}개</p>
-              <p className="font-bold">{product.discountedPrice.toLocaleString()}원</p>
+            {/* Mobile Image */}
+            <Image
+              src={product.coverImage}
+              alt={product.title}
+              width={100}
+              height={70}
+              className="block w-full rounded md:hidden"
+            />
+
+            {/* Product Information */}
+            <div className="flex flex-col md:grow md:flex-row md:items-center md:justify-between md:gap-x-4">
+              <p className="text-sm font-extralight md:flex-1">{product.title}</p>
+              <p className="mt-2 text-sm md:mt-0">{product.quantity}개</p>
+              <p className="mt-1 font-bold md:mt-0">{product.discountedPrice.toLocaleString()}원</p>
             </div>
           </div>
         ))}

--- a/apps/commerce-client-web/src/app/(default)/order/page.tsx
+++ b/apps/commerce-client-web/src/app/(default)/order/page.tsx
@@ -24,7 +24,7 @@ const PaymentPage = async ({ searchParams }: OrderPageProps) => {
   const productResponse = await getProductForOrder({ products });
 
   return (
-    <div className="container mx-auto p-6">
+    <div className="p-4 sm:p-0">
       <h1 className="mb-8 text-left text-xl font-semibold">결제 정보</h1>
       <div className="grid gap-6 md:grid-cols-1 lg:grid-cols-2">
         <PaymentProducts books={productResponse.products} />

--- a/apps/commerce-client-web/src/app/actions/auth-action.ts
+++ b/apps/commerce-client-web/src/app/actions/auth-action.ts
@@ -59,10 +59,7 @@ export const logout = async () => {
   if (!response.success) {
     throw new Error(response.error?.message);
   }
-
-  // Clear cookies on logout
   removeTokenInfo();
-
   redirect('/');
 };
 

--- a/apps/commerce-client-web/src/app/actions/my-review-action.ts
+++ b/apps/commerce-client-web/src/app/actions/my-review-action.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { externalApi } from '@/lib/api';
 import type { ApiResponse } from '@/types/api-types';
 import { MyReviewResponse } from '@/types/my-review-type';
 import { getHeadersWithToken } from './utils/action-helper';
+import { api } from '@/lib/api';
 
 export const getMyReviews = async (): Promise<MyReviewResponse> => {
   const headers = await getHeadersWithToken();
@@ -12,7 +12,7 @@ export const getMyReviews = async (): Promise<MyReviewResponse> => {
     throw new Error('No token found');
   }
 
-  const response = await externalApi
+  const response = await api
     .get('product/v1/reviews/me', { headers })
     .json<ApiResponse<MyReviewResponse>>();
 

--- a/apps/commerce-client-web/src/components/layout/header-hamburgermenu.tsx
+++ b/apps/commerce-client-web/src/components/layout/header-hamburgermenu.tsx
@@ -4,14 +4,21 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { MainMenu } from '@/types/menu-types';
 import Link from 'next/link';
-import useAuthStore from '@/stores/use-auth-store';
+import { useAuthStore } from '@/stores/use-auth-store';
 import { logout } from '@/app/actions/auth-action';
 import { usePathname, useRouter } from 'next/navigation';
 import { useUserStore } from '@/stores/use-user-store';
+import { ShoppingCartIcon } from 'lucide-react';
 
 interface HamburgerMenuProps {
   mainMenu: MainMenu[];
 }
+
+const myPageMenu = [
+  { title: '주문내역/배송조회', route: '/me/orders' },
+  { title: '회원정보관리', route: '/me/user-info' },
+  { title: '나의 리뷰', route: '/me/reviews' },
+];
 
 const HamburgerMenu = ({ mainMenu }: HamburgerMenuProps) => {
   const router = useRouter();
@@ -78,27 +85,32 @@ const HamburgerMenu = ({ mainMenu }: HamburgerMenuProps) => {
   return (
     <div className="relative">
       {/* Hamburger Button */}
-      <button
-        className="flex size-8 flex-col items-center justify-center space-y-1 border-none bg-transparent focus:outline-none"
-        onClick={toggleMenu}
-        aria-label="Toggle menu"
-      >
-        <span
-          className={`block h-0.5 w-6 bg-current transition-transform${
-            isOpen ? ' translate-y-1.5 rotate-45' : ''
-          }`}
-        />
-        <span
-          className={`block h-0.5 w-6 bg-current transition-opacity ${
-            isOpen ? ' opacity-0' : ' opacity-100'
-          }`}
-        />
-        <span
-          className={`block h-0.5 w-6 bg-current transition-transform${
-            isOpen ? ' -translate-y-1.5 -rotate-45' : ''
-          }`}
-        />
-      </button>
+      <div className="flex items-center gap-x-5">
+        <Link href="/cart">
+          <ShoppingCartIcon size={25} />
+        </Link>
+        <button
+          className="flex size-8 flex-col items-center justify-center space-y-1 border-none bg-transparent focus:outline-none"
+          onClick={toggleMenu}
+          aria-label="Toggle menu"
+        >
+          <span
+            className={`block h-0.5 w-6 bg-current transition-transform${
+              isOpen ? ' translate-y-1.5 rotate-45' : ''
+            }`}
+          />
+          <span
+            className={`block h-0.5 w-6 bg-current transition-opacity ${
+              isOpen ? ' opacity-0' : ' opacity-100'
+            }`}
+          />
+          <span
+            className={`block h-0.5 w-6 bg-current transition-transform${
+              isOpen ? ' -translate-y-1.5 -rotate-45' : ''
+            }`}
+          />
+        </button>
+      </div>
 
       {isOpen && (
         <div className="fixed inset-0 top-14 z-50 flex w-full max-w-[100vw] flex-col overflow-y-auto border-t bg-white">
@@ -122,11 +134,12 @@ const HamburgerMenu = ({ mainMenu }: HamburgerMenuProps) => {
                   variant="outline"
                   className="border-primary text-primary max-w-40 flex-1 rounded-full"
                 >
-                  <Link href={'/join'}>회원가입</Link>
+                  <Link href={'/signup'}>회원가입</Link>
                 </Button>
               </>
             )}
           </div>
+
           <ul className="flex w-full flex-col space-y-2 px-4">
             {mainMenu.map((menu, index) => (
               <li key={index}>
@@ -176,6 +189,24 @@ const HamburgerMenu = ({ mainMenu }: HamburgerMenuProps) => {
               </li>
             ))}
           </ul>
+
+          {/* 새로운 MyPage 메뉴 섹션 (로그인 상태일 때만 표시) */}
+          {isLoggedIn && (
+            <div className="mx-4 mt-4 border-t pt-4">
+              <h3 className="font-semibold text-slate-700">마이페이지</h3>
+              <ul className="mt-2 flex flex-col space-y-2">
+                {myPageMenu.map((menu, index) => (
+                  <li key={index}>
+                    <Link href={menu.route} onClick={closeMenu}>
+                      <span className="block rounded-md p-2 text-slate-600 hover:bg-slate-200">
+                        {menu.title}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/commerce-client-web/src/components/layout/top-bar.tsx
+++ b/apps/commerce-client-web/src/components/layout/top-bar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import useAuthStore from '@/stores/use-auth-store';
 import NavLinks from '@/components/common/nav-links';
 import { logout } from '@/app/actions/auth-action';
 import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/stores/use-user-store';
+import { useAuthStore } from '@/stores/use-auth-store';
 
 const TopBar = () => {
   const router = useRouter();

--- a/apps/commerce-client-web/src/stores/use-auth-store.ts
+++ b/apps/commerce-client-web/src/stores/use-auth-store.ts
@@ -33,7 +33,7 @@ interface AuthStore {
   resetAuthState: () => void;
 }
 
-const useAuthStore = create<AuthStore>()(
+export const useAuthStore = create<AuthStore>()(
   devtools(
     persist(
       (set) => ({
@@ -112,5 +112,3 @@ const useAuthStore = create<AuthStore>()(
     ),
   ),
 );
-
-export default useAuthStore;


### PR DESCRIPTION
# feature/cart-order-reponsive-design

## 🔘Part

- [x] 장바구니 및 주문하기 반응형 디자인
- [x] 모바일 헤더 마이페이지 접근 가능하도록 링크 추가 

<br/>

## 🔎 작업 내용

- 장바구니 안에 담긴 상품 없었을 때의 UI 작업

- 모바일 헤더에서 장바구니로 접근할 수 있도록 버튼 추가

- 주문하기에서 payments-products 반응형 디자인 적용

  <br/>

## 이미지 첨부

<img width="334" alt="image" src="https://github.com/user-attachments/assets/b351da41-a49f-44a5-9065-aed6c54025d4">
<img width="335" alt="image" src="https://github.com/user-attachments/assets/1b3f6e20-3fa0-4ef8-ad5d-b30195d727ac">
<img width="332" alt="image" src="https://github.com/user-attachments/assets/c6f79556-12d9-4e90-8663-d9968c900e86">


<br/>
