### PR TITLE
Fix/pagenation bug

### DIFF
--- a/apps/commerce-client-web/src/app/(default)/details/[id]/components/product-summury.tsx
+++ b/apps/commerce-client-web/src/app/(default)/details/[id]/components/product-summury.tsx
@@ -1,6 +1,6 @@
 import StarRating from '@/components/common/star-rating';
 import { Button } from '@/components/ui/button';
-import { parseAndRoundPrice, calculationDiscountRate } from '@/lib/utils';
+import { calculationDiscountRate } from '@/lib/utils';
 import { Product } from '@/types/product-types';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -11,8 +11,6 @@ interface ProductSummuryProps {
 }
 
 const ProductSummury = ({ book }: ProductSummuryProps) => {
-  const originalPrice = parseAndRoundPrice(book.price);
-  const discountedPrice = parseAndRoundPrice(book.discountedPrice);
   const discountRate = calculationDiscountRate(book.price, book.discountedPrice);
 
   return (
@@ -63,10 +61,12 @@ const ProductSummury = ({ book }: ProductSummuryProps) => {
             <div className="py-4">
               <div className="grid grid-cols-[120px_1fr] items-center gap-y-2 text-sm">
                 <div className="w-28 font-extralight text-slate-500">정가</div>
-                <div className="text-left font-extrabold line-through">{originalPrice}원</div>
+                <div className="text-left font-extrabold line-through">
+                  {book.price.toLocaleString()}원
+                </div>
                 <div className="w-28 font-extralight text-slate-500">판매가</div>
                 <div className="text-destructive text-left text-base">
-                  <span className="font-extrabold">{discountedPrice}원</span>
+                  <span className="font-extrabold">{book.discountedPrice.toLocaleString()}원</span>
                   <span className="ml-1 text-xs font-light">({discountRate}%)</span>
                 </div>
               </div>

--- a/apps/commerce-client-web/src/app/(default)/search/components/(filters)/filter-component.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/(filters)/filter-component.tsx
@@ -2,9 +2,7 @@
 
 import { Accordion } from '@/components/ui/accordion';
 import PriceFilter from './price-filter';
-// import PublisherFilter from './publisher-filter';
 import CategoryFilter from './category-filter';
-import { Suspense } from 'react';
 import { Product } from '@/types/product-types';
 
 interface FilterComponentProps {
@@ -16,9 +14,6 @@ const FilterComponent = ({ books }: FilterComponentProps) => {
     <div className="w-full max-w-md rounded-lg border p-4">
       <Accordion type="multiple" className="w-full">
         <PriceFilter />
-        <Suspense fallback="로딩 중..">
-          {/* <PublisherFilter publishers={publishers} /> */}
-        </Suspense>
         <CategoryFilter books={books} />
       </Accordion>
     </div>

--- a/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/book-card.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/book-card.tsx
@@ -2,7 +2,6 @@
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation'; // useRouter 훅 가져오기
-import { parseAndRoundPrice } from '@/lib/utils';
 import { Product } from '@/types/product-types'; // Import the useCartStore hook
 import AddToCartButton from '@/app/(default)/cart/components/cart-add-button';
 import PaymentAddButton from '@/app/(default)/order/components/payment-add-button';
@@ -15,8 +14,6 @@ export type BookCardProps = {
 const BookCard = ({ id, book }: BookCardProps) => {
   const router = useRouter(); // useRouter 훅 사용
   const maxLength = 100; // 최대 출력할 글자 수
-
-  const roundedPrice = parseAndRoundPrice(book.price); // 유틸리티 함수 사용
 
   const handleNavigate = () => {
     router.push(`/details/${id}`);
@@ -55,7 +52,7 @@ const BookCard = ({ id, book }: BookCardProps) => {
                   {book.discountedPrice.toLocaleString()}원
                 </span>
                 <span className="text-xs text-slate-400 line-through lg:text-sm">
-                  {roundedPrice.toLocaleString()}원
+                  {book.price.toLocaleString()}원
                 </span>
               </>
             ) : (

--- a/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/product-list.tsx
+++ b/apps/commerce-client-web/src/app/(default)/search/components/(searchResult)/product-list.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import CustomPagination from '@/components/common/custom-pagenation';
 import { Product } from '@/types/product-types';
 import { Pagination } from '@/types/pagination-types';
@@ -11,6 +12,17 @@ interface ProductListProps {
 }
 
 const ProductList = ({ books, pagination }: ProductListProps) => {
+  const searchParams = useSearchParams();
+
+  const generatePageLink = (page: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    // Update or add the page parameter
+    params.set('page', page.toString());
+
+    return `?${params.toString()}`;
+  };
+
   return (
     <div>
       <SearchResult books={books} />
@@ -21,7 +33,7 @@ const ProductList = ({ books, pagination }: ProductListProps) => {
           totalPage={pagination.totalPage}
           hasNext={pagination.hasNextPage}
           hasPrev={pagination.hasPreviousPage}
-          generatePageLink={(page) => `?page=${page}`} // Define how the link should look
+          generatePageLink={generatePageLink} // Use the modified function
         />
       )}
     </div>


### PR DESCRIPTION
# fix/pagenation-bug

ex) feat(17): pull request template 작성 (확인 후 지워주세요)

## 🔘Part

- [x] 상품 검색에서 페이지 이동할 때, 기존의 searchParams 사라지는 버그 수정
- [x] 상품 상세 가격과 장바구니 가격 다른 것 수정 

<br/>

## 🔎 작업 내용

- search page에서 product list에서 기존의 search params는 유지하면서, page params만 추가되도록 수정
- 상품 가격 반올림하지 않고, 서버에서 내려준대로 사용하도록 수정

  <br/>

## 이미지 첨부

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/77c35b63-45ff-4e70-932d-9cdbaa428feb">
<img width="1304" alt="image" src="https://github.com/user-attachments/assets/a0d7164a-f2aa-4ca6-b0ba-e1596bda5e65">

<br/>

## ➕ 이슈 링크

- #67 

<br/>
